### PR TITLE
Handle frame close via URL parameter

### DIFF
--- a/apps/web/src/app/(authenticated)/frame/page.tsx
+++ b/apps/web/src/app/(authenticated)/frame/page.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import Screensaver from "@/components/dashboard/Screensaver";
 
 export default function FramePage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   return (
     <Screensaver
       active
       onExit={() => {
+        if (searchParams.get("closeAction") === "urlParam") {
+          const nextParams = new URLSearchParams(searchParams);
+          nextParams.set("closeActionTriggered", "1");
+          setSearchParams(nextParams, { replace: true });
+          return;
+        }
+
         navigate("/home");
       }}
     />


### PR DESCRIPTION
## Summary
- detect `closeAction=urlParam` on the `/frame` page
- set `closeActionTriggered=1` in the current URL when the frame close control is pressed
- preserve existing `/home` navigation for all other close actions

## Testing
- `bun run lint` (blocked in clean worktree: `eslint` command not found without dependencies)
- `bunx tsc --noEmit` (blocked in clean worktree: missing `bun`/`node` type definitions without dependencies)