### PR TITLE
Improve saved article lists and add AIO dev workflow

### DIFF
--- a/.github/workflows/aio-dev.yml
+++ b/.github/workflows/aio-dev.yml
@@ -1,0 +1,44 @@
+name: Build and Publish aio-dev
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies and build web app
+        run: |
+          cd apps/web
+          bun install
+          bun run build
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and Push Multi-Arch Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ secrets.DOCKER_USERNAME }}/dashwise:aio-dev

--- a/apps/backend/src/lib/data/news.ts
+++ b/apps/backend/src/lib/data/news.ts
@@ -107,7 +107,7 @@ export type NewsFeedRecordCreateInput = {
 
 export type NewsSavedArticle = {
   id: string;
-  list: string;
+  list: string[];
   isRead?: boolean;
   json: NewsFeedItem;
   userId?: string;
@@ -115,9 +115,14 @@ export type NewsSavedArticle = {
   updated?: string;
 };
 
+export type NewsSavedArticleList = {
+  id: string;
+  name: string;
+};
+
 export type NewsSavedArticlesResponse = {
   articles: NewsSavedArticle[];
-  lists: string[];
+  lists: NewsSavedArticleList[];
   defaultList: string;
 };
 
@@ -129,10 +134,22 @@ function normalizeListName(list?: string | null) {
   return String(list || "").trim() || "readLater";
 }
 
+function normalizeListIds(list?: unknown): string[] {
+  const values = Array.isArray(list) ? list : list ? [list] : [];
+  return Array.from(new Set(values.map((value) => String(value).trim()).filter(Boolean)));
+}
+
+function normalizeSavedArticleList(record: Record<string, unknown>): NewsSavedArticleList {
+  return {
+    id: String(record.id || ""),
+    name: normalizeListName(String(record.name || "")),
+  };
+}
+
 function normalizeSavedArticle(record: Record<string, unknown>): NewsSavedArticle {
   return {
     id: String(record.id || ""),
-    list: normalizeListName(String(record.list || "")),
+    list: normalizeListIds(record.list),
     isRead: Boolean(record.isRead),
     json: (record.json && typeof record.json === "object" ? record.json : {}) as NewsFeedItem,
     userId: record.userId ? String(record.userId) : undefined,
@@ -156,6 +173,38 @@ async function ensureNewsDefaultList(userId: string) {
   }
 
   return defaultList;
+}
+
+async function ensureNewsSavedArticleList(userId: string, list?: string | null): Promise<NewsSavedArticleList> {
+  const pb = await getSuperuserPB();
+  const target = normalizeListName(list);
+  const collection = pb.collection("newsSavedArticleLists");
+  const byId = await collection.getOne(target).catch(() => null) as Record<string, unknown> | null;
+  if (byId && String(byId.userId || "") === userId) {
+    return normalizeSavedArticleList(byId);
+  }
+
+  const existing = await collection.getFullList(200, {
+    filter: `userId=\"${escapeFilter(userId)}\" && name=\"${escapeFilter(target)}\"`,
+  }) as Array<Record<string, unknown>>;
+
+  if (existing[0]) {
+    return normalizeSavedArticleList(existing[0]);
+  }
+
+  const created = await collection.create({ userId, name: target });
+  return normalizeSavedArticleList(created as Record<string, unknown>);
+}
+
+async function getNewsSavedArticleLists(userId: string, defaultList: string): Promise<NewsSavedArticleList[]> {
+  const defaultRecord = await ensureNewsSavedArticleList(userId, defaultList);
+  const pb = await getSuperuserPB();
+  const records = await pb.collection("newsSavedArticleLists").getFullList(200, {
+    filter: `userId=\"${escapeFilter(userId)}\"`,
+    sort: "name",
+  }) as Array<Record<string, unknown>>;
+  const lists = records.map(normalizeSavedArticleList);
+  return lists.some((list) => list.id === defaultRecord.id) ? lists : [defaultRecord, ...lists];
 }
 
 function itemTime(item: NewsFeedItem): number {
@@ -617,11 +666,12 @@ export async function getNewsFeeds(userId: string): Promise<NewsFeedsResponse> {
 
 export async function getNewsSavedArticles(userId: string, list?: string | null): Promise<NewsSavedArticlesResponse> {
   const defaultList = await ensureNewsDefaultList(userId);
+  const lists = await getNewsSavedArticleLists(userId, defaultList);
   const targetList = String(list || "").trim();
   const pb = await getSuperuserPB();
   const filters = [`userId=\"${escapeFilter(userId)}\"`];
   if (targetList) {
-    filters.push(`list=\"${escapeFilter(targetList)}\"`);
+    filters.push(`list ?= \"${escapeFilter(targetList)}\"`);
   }
 
   const records = await pb.collection("newsSavedArticles").getFullList(2000, {
@@ -630,14 +680,13 @@ export async function getNewsSavedArticles(userId: string, list?: string | null)
   }) as Array<Record<string, unknown>>;
 
   const articles = records.map(normalizeSavedArticle);
-  const lists = Array.from(new Set([defaultList, ...articles.map((article) => article.list)].filter(Boolean))).sort((left, right) => left.localeCompare(right));
 
-  return { articles, lists, defaultList };
+  return { articles, lists, defaultList: lists.find((entry) => entry.name === defaultList)?.id || lists[0]?.id || defaultList };
 }
 
 export async function saveNewsArticle(userId: string, article: NewsFeedItem, list?: string | null): Promise<NewsSavedArticle> {
   const defaultList = await ensureNewsDefaultList(userId);
-  const targetList = normalizeListName(list || defaultList);
+  const listRecord = await ensureNewsSavedArticleList(userId, list || defaultList);
   const link = String(article?.link || "").trim();
   if (!link) {
     throw new Error("Article link is required");
@@ -645,14 +694,14 @@ export async function saveNewsArticle(userId: string, article: NewsFeedItem, lis
 
   const pb = await getSuperuserPB();
   const existingRecords = await pb.collection("newsSavedArticles").getFullList(2000, {
-    filter: `userId=\"${escapeFilter(userId)}\" && list=\"${escapeFilter(targetList)}\"`,
+    filter: `userId=\"${escapeFilter(userId)}\" && list ?= \"${escapeFilter(listRecord.id)}\"`,
   }) as Array<Record<string, unknown>>;
   const existing = existingRecords.find((record) => {
     const json = record.json && typeof record.json === "object" ? record.json as Record<string, unknown> : {};
     return String(json.link || "").trim() === link;
   }) || null;
 
-  const payload = { userId, list: targetList, isRead: false, json: article };
+  const payload = { userId, list: [listRecord.id], isRead: false, json: article };
   const saved = existing?.id
     ? await pb.collection("newsSavedArticles").update(String(existing.id), payload)
     : await pb.collection("newsSavedArticles").create(payload);

--- a/apps/web/src/components/news/NewsDashboard.tsx
+++ b/apps/web/src/components/news/NewsDashboard.tsx
@@ -470,7 +470,7 @@ export default function NewsDashboardComponent() {
     };
 
     const openSaveDialog = (article: NewsFeedItem) => {
-        const defaultList = savedArticlesData?.defaultList || "readLater";
+        const defaultList = savedArticlesData?.defaultList || savedArticlesData?.lists?.[0]?.id || "readLater";
         setSaveDialogArticle(article);
         setSaveListSelection(defaultList);
         setNewSaveListName("");
@@ -814,8 +814,8 @@ export default function NewsDashboardComponent() {
                                 value={saveListSelection}
                                 onChange={(event) => setSaveListSelection(event.target.value)}
                             >
-                                {(savedArticlesData?.lists?.length ? savedArticlesData.lists : ["readLater"]).map((list) => (
-                                    <option key={list} value={list}>{list}</option>
+                                {(savedArticlesData?.lists?.length ? savedArticlesData.lists : [{ id: "readLater", name: "readLater" }]).map((list) => (
+                                    <option key={list.id} value={list.id}>{list.name}</option>
                                 ))}
                             </select>
                         </div>
@@ -859,7 +859,7 @@ function NewsArticle({ item, iconUrl, isSaved, onSave, onSaveOptions }: { item: 
                     <div className="w-full h-45 frosted rounded-xl" />}
                     <button
                         type="button"
-                        className={`absolute right-2 top-2 flex h-9 w-9 items-center justify-center rounded-full frosted transition ${isSaved ? "bg-(--accent)/20 ring-1 ring-(--accent)" : "bg-black/30 hover:bg-black/50"}`}
+                        className="absolute right-2 top-2 flex h-9 w-9 items-center justify-center rounded-full bg-black/30 frosted transition hover:bg-black/50 group"
                         title={isSaved ? "Saved to list" : "Save article"}
                         onClick={(event) => {
                             event.preventDefault();
@@ -870,7 +870,7 @@ function NewsArticle({ item, iconUrl, isSaved, onSave, onSaveOptions }: { item: 
                             onSaveOptions?.();
                         }}
                     >
-                        <Icon icon="fa6-solid:bookmark" className={isSaved ? "text-(--accent)" : "text-white/90"} />
+                        <Icon icon={isSaved ? "fa6-solid:square-check" : "fa6-solid:bookmark"} className={isSaved ? "text-(--accent)" : "text-white/90 group-hover:text-(--accent)"} />
                     </button>
                 </div>
 

--- a/apps/web/src/components/news/NewsLayout.tsx
+++ b/apps/web/src/components/news/NewsLayout.tsx
@@ -23,6 +23,11 @@ interface FeedRecord {
     title?: string;
 }
 
+interface SavedListRecord {
+    id: string;
+    name: string;
+}
+
 export default function NewsLayout({ children }: { children: ReactNode }) {
     const { token, withAuth } = useAuth();
     const navigate = useNavigate();
@@ -30,7 +35,7 @@ export default function NewsLayout({ children }: { children: ReactNode }) {
     const [searchParams] = useSearchParams();
     const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
     const [feeds, setFeeds] = useState<FeedRecord[]>([]);
-    const [savedLists, setSavedLists] = useState<string[]>([]);
+    const [savedLists, setSavedLists] = useState<SavedListRecord[]>([]);
     const [sidebarRefreshVersion, setSidebarRefreshVersion] = useState(0);
 
     useEffect(() => {
@@ -63,7 +68,7 @@ export default function NewsLayout({ children }: { children: ReactNode }) {
 
                 setSubscriptions(subscriptionsData?.subscriptions ?? []);
                 setFeeds(Array.isArray(feedsData?.feeds) ? feedsData.feeds : []);
-                setSavedLists(Array.isArray(savedData?.lists) ? savedData.lists : ["readLater"]);
+                setSavedLists(Array.isArray(savedData?.lists) ? savedData.lists : [{ id: "readLater", name: "readLater" }]);
             } catch (error) {
                 console.error("Failed to load news subscriptions:", error);
                 if (mounted) {
@@ -183,12 +188,12 @@ export default function NewsLayout({ children }: { children: ReactNode }) {
                     collapsible={true}
                 />
 
-                {(savedLists.length ? savedLists : ["readLater"]).map((list) => (
+                {(savedLists.length ? savedLists : [{ id: "readLater", name: "readLater" }]).map((list) => (
                     <Tab
-                        key={list}
-                        dst={`/apps/news/saved-${encodeURIComponent(list)}`}
+                        key={list.id}
+                        dst={`/apps/news/saved-${encodeURIComponent(list.id)}`}
                         icon="fa6-solid:bookmark"
-                        title={list}
+                        title={list.name}
                         group="Saved"
                     />
                 ))}

--- a/packages/types/sdk-types.ts
+++ b/packages/types/sdk-types.ts
@@ -106,7 +106,7 @@ export type NewsFeedItem = {
 
 export type NewsSavedArticle = {
   id: string;
-  list: string;
+  list: string[];
   isRead?: boolean;
   json: NewsFeedItem;
   userId?: string;
@@ -114,9 +114,14 @@ export type NewsSavedArticle = {
   updated?: string;
 };
 
+export type NewsSavedArticleList = {
+  id: string;
+  name: string;
+};
+
 export type NewsSavedArticlesResponse = {
   articles: NewsSavedArticle[];
-  lists: string[];
+  lists: NewsSavedArticleList[];
   defaultList: string;
 };
 

--- a/pocketbase/migrations/1781992300_created_newsSavedArticleLists.js
+++ b/pocketbase/migrations/1781992300_created_newsSavedArticleLists.js
@@ -1,0 +1,148 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const lists = new Collection({
+    "createRule": null,
+    "deleteRule": null,
+    "fields": [
+      {
+        "autogeneratePattern": "[a-z0-9]{15}",
+        "hidden": false,
+        "id": "text3208210256",
+        "max": 15,
+        "min": 15,
+        "name": "id",
+        "pattern": "^[a-z0-9]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text2193810834",
+        "max": 0,
+        "min": 0,
+        "name": "name",
+        "pattern": "",
+        "presentable": true,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "cascadeDelete": true,
+        "collectionId": "_pb_users_auth_",
+        "hidden": false,
+        "id": "relation2839102431",
+        "maxSelect": 1,
+        "minSelect": 0,
+        "name": "userId",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "relation"
+      },
+      {
+        "hidden": false,
+        "id": "autodate2990389176",
+        "name": "created",
+        "onCreate": true,
+        "onUpdate": false,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      },
+      {
+        "hidden": false,
+        "id": "autodate3332085495",
+        "name": "updated",
+        "onCreate": true,
+        "onUpdate": true,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      }
+    ],
+    "id": "pbc_1781992300",
+    "indexes": ["CREATE UNIQUE INDEX `idx_newsSavedArticleLists_user_name` ON `newsSavedArticleLists` (`userId`, `name`)"] ,
+    "listRule": null,
+    "name": "newsSavedArticleLists",
+    "system": false,
+    "type": "base",
+    "updateRule": null,
+    "viewRule": null
+  });
+
+  app.save(lists);
+
+  const articleListRefs = [];
+  const listByUserAndName = {};
+  const existingArticles = app.findRecordsByFilter("newsSavedArticles", "", "", 10000, 0);
+  for (const article of existingArticles) {
+    const userId = String(article.get("userId") || "");
+    const listName = String(article.get("list") || "").trim() || "readLater";
+    const key = `${userId}:${listName}`;
+
+    if (!listByUserAndName[key]) {
+      const listRecord = new Record(lists);
+      listRecord.set("name", listName);
+      if (userId) {
+        listRecord.set("userId", userId);
+      }
+      app.save(listRecord);
+      listByUserAndName[key] = listRecord.id;
+    }
+
+    articleListRefs.push({ id: article.id, listId: listByUserAndName[key] });
+  }
+
+  const articles = app.findCollectionByNameOrId("pbc_708912430");
+  articles.fields.removeByName("list");
+  articles.fields.addAt(1, new Field({
+    "cascadeDelete": false,
+    "collectionId": "pbc_1781992300",
+    "hidden": false,
+    "id": "relation3719284361",
+    "maxSelect": 999,
+    "minSelect": 0,
+    "name": "list",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "relation"
+  }));
+
+  app.save(articles);
+
+  for (const ref of articleListRefs) {
+    const article = app.findRecordById("newsSavedArticles", ref.id);
+    article.set("list", [ref.listId]);
+    app.save(article);
+  }
+
+  return true;
+}, (app) => {
+  const articles = app.findCollectionByNameOrId("pbc_708912430");
+  articles.fields.removeById("relation3719284361");
+  articles.fields.addAt(1, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text1154021400",
+    "max": 0,
+    "min": 0,
+    "name": "list",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }));
+  app.save(articles);
+
+  const lists = app.findCollectionByNameOrId("pbc_1781992300");
+  return app.delete(lists);
+})


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and publishes the aio-dev Docker image on pushes to dev
- add a newsSavedArticleLists PocketBase collection and migrate saved articles to list relations
- update saved article responses/types/sidebar routes to use saved list records
- update read-later save affordance hover color and saved checkbox icon state

## Testing
- bun run typecheck
- bun run lint (blocked in clean worktree: eslint command not found without dependencies)
- bunx tsc --noEmit (blocked in clean worktree: missing bun/node type definitions without dependencies)

Closes #232