### PR TITLE
feat(news): group similar articles by topic

### DIFF
--- a/apps/backend/src/lib/data/news.ts
+++ b/apps/backend/src/lib/data/news.ts
@@ -25,7 +25,16 @@ export type NewsFeedItem = {
   pubDate: string | Date;
   subscription_id: string;
   subscription_name: string;
+  topicId?: string;
+  topicTitle?: string;
+  relatedArticles?: NewsFeedItem[];
   [key: string]: unknown;
+};
+
+type NewsTopicDraft = {
+  key: string;
+  title: string;
+  articles: NewsFeedItem[];
 };
 
 export type NewsSubscription = {
@@ -166,6 +175,169 @@ function itemTime(item: NewsFeedItem): number {
     return Number.isNaN(time) ? 0 : time;
   }
   return 0;
+}
+
+function articleKey(item: NewsFeedItem) {
+  return String(item.link || item.title || "").trim().toLowerCase();
+}
+
+function textValue(value: unknown) {
+  if (Array.isArray(value)) return value.join(" ");
+  return String(value || "");
+}
+
+const topicStopWords = new Set([
+  "about", "after", "again", "also", "amid", "because", "before", "being", "could", "from", "have", "into",
+  "more", "news", "over", "said", "says", "that", "their", "there", "this", "through", "update", "using", "what",
+  "when", "where", "which", "while", "with", "will", "would", "your",
+]);
+
+function topicTokens(item: NewsFeedItem) {
+  const weighted = [
+    textValue(item.title),
+    textValue(item.title),
+    textValue(item.description),
+    textValue(item.summary),
+    textValue(item.categories),
+    textValue(item.tags),
+    textValue(item.categories),
+    textValue(item.tags),
+  ].join(" ");
+
+  return weighted
+    .toLowerCase()
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(" ")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 3 && !topicStopWords.has(token));
+}
+
+function uniqueTopicTokens(item: NewsFeedItem) {
+  return new Set(topicTokens(item));
+}
+
+function similarity(left: NewsFeedItem, right: NewsFeedItem) {
+  const leftTokens = uniqueTopicTokens(left);
+  const rightTokens = uniqueTopicTokens(right);
+  if (!leftTokens.size || !rightTokens.size) return 0;
+
+  let overlap = 0;
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) overlap++;
+  }
+
+  return overlap / Math.min(leftTokens.size, rightTokens.size);
+}
+
+function topicKeyFor(articles: NewsFeedItem[]) {
+  const counts = new Map<string, number>();
+  for (const article of articles) {
+    for (const token of uniqueTopicTokens(article)) {
+      counts.set(token, (counts.get(token) || 0) + 1);
+    }
+  }
+
+  const tokens = Array.from(counts.entries())
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, 5)
+    .map(([token]) => token);
+
+  return tokens.join("-") || articleKey(articles[0]);
+}
+
+function topicTitleFor(articles: NewsFeedItem[]) {
+  const newest = [...articles].sort((left, right) => itemTime(right) - itemTime(left))[0];
+  const title = String(newest?.title || "Related stories").trim();
+  return title.length > 96 ? `${title.slice(0, 93)}...` : title;
+}
+
+function buildNewsTopics(feed: NewsFeedItem[]): NewsTopicDraft[] {
+  const topics: NewsTopicDraft[] = [];
+  const assigned = new Set<string>();
+  const sorted = [...feed].sort((left, right) => itemTime(right) - itemTime(left));
+
+  for (const lead of sorted) {
+    const leadKey = articleKey(lead);
+    if (!leadKey || assigned.has(leadKey)) continue;
+
+    const related = sorted
+      .filter((candidate) => {
+        const candidateKey = articleKey(candidate);
+        if (!candidateKey || candidateKey === leadKey || assigned.has(candidateKey)) return false;
+        if (Math.abs(itemTime(lead) - itemTime(candidate)) > 1000 * 60 * 60 * 72) return false;
+        return similarity(lead, candidate) >= 0.35;
+      })
+      .slice(0, 4);
+
+    if (!related.length) continue;
+
+    const articles = [lead, ...related];
+    for (const article of articles) assigned.add(articleKey(article));
+    topics.push({
+      key: topicKeyFor(articles),
+      title: topicTitleFor(articles),
+      articles,
+    });
+  }
+
+  return topics;
+}
+
+async function persistNewsTopics(userId: string, topics: NewsTopicDraft[]) {
+  const pb = await getSuperuserPB();
+  const persisted = new Map<string, Record<string, unknown>>();
+
+  for (const topic of topics) {
+    const payload = {
+      userId,
+      key: topic.key,
+      title: topic.title,
+      newestArticleLink: String(topic.articles[0]?.link || ""),
+      articleLinks: topic.articles.map((article) => String(article.link || "")).filter(Boolean),
+      json: topic.articles,
+    };
+
+    const existing = await pb.collection("newsTopics").getFirstListItem(
+      `userId=\"${escapeFilter(userId)}\" && topicKey=\"${escapeFilter(topic.key)}\"`,
+    ).catch(() => null) as Record<string, unknown> | null;
+    const record = existing?.id
+      ? await pb.collection("newsTopics").update(String(existing.id), payload)
+      : await pb.collection("newsTopics").create(payload);
+    persisted.set(topic.key, record as Record<string, unknown>);
+  }
+
+  return persisted;
+}
+
+async function applyNewsTopics(userId: string, feed: NewsFeedItem[]) {
+  const topics = buildNewsTopics(feed);
+  if (!topics.length) return feed;
+
+  const persisted = await persistNewsTopics(userId, topics).catch(() => new Map<string, Record<string, unknown>>());
+  const relatedKeys = new Set<string>();
+  const leadByKey = new Map<string, NewsFeedItem>();
+
+  for (const topic of topics) {
+    const record = persisted.get(topic.key);
+    const topicId = String(record?.id || topic.key);
+    const [lead, ...relatedArticles] = topic.articles;
+    for (const related of relatedArticles) relatedKeys.add(articleKey(related));
+    leadByKey.set(articleKey(lead), {
+      ...lead,
+      topicId,
+      topicTitle: topic.title,
+      relatedArticles: relatedArticles.map((article) => ({
+        ...article,
+        topicId,
+        topicTitle: topic.title,
+      })),
+    });
+  }
+
+  return feed
+    .filter((article) => !relatedKeys.has(articleKey(article)))
+    .map((article) => leadByKey.get(articleKey(article)) ?? article);
 }
 
 function normalizeSubscription(entry: Record<string, unknown> | null): NewsSubscription | null {
@@ -567,7 +739,7 @@ export async function getNewsFeed(userId: string, feedId?: string | null): Promi
     : subscriptions.filter((subscription) => !excludedIds.has(String(subscription.id || "")));
 
   const feed = await buildFeedFromSubscriptions(scopedSubscriptions, feedId, feeds);
-  return feed;
+  return applyNewsTopics(userId, feed);
 }
 
 export async function getNewsSubscriptions(userId: string): Promise<NewsSubscriptionsResponse> {

--- a/apps/web/src/components/news/NewsDashboard.tsx
+++ b/apps/web/src/components/news/NewsDashboard.tsx
@@ -566,13 +566,13 @@ export default function NewsDashboardComponent() {
 
                         {feed &&
                 paginatedArticles.map((item, idx) => (
-                                <NewsArticle
-                                    key={idx}
+                                <NewsTopicGroup
+                                    key={String(item.link || idx)}
                                     item={item}
-                                    iconUrl={getIconUrl(item.subscription_id || item.subscription_name)}
-                                    isSaved={isArticleSaved(item)}
-                                    onSave={() => saveArticle(item)}
-                                    onSaveOptions={() => openSaveDialog(item)}
+                                    getIconUrl={getIconUrl}
+                                    isArticleSaved={isArticleSaved}
+                                    saveArticle={saveArticle}
+                                    openSaveDialog={openSaveDialog}
                                 />
                             ))}
 
@@ -843,7 +843,75 @@ export default function NewsDashboardComponent() {
     );
 }
 
-function NewsArticle({ item, iconUrl, isSaved, onSave, onSaveOptions }: { item: any; iconUrl?: string; isSaved?: boolean; onSave?: () => void; onSaveOptions?: () => void }) {
+function NewsTopicGroup({ item, getIconUrl, isArticleSaved, saveArticle, openSaveDialog }: {
+    item: NewsFeedItem;
+    getIconUrl: (name: string) => string | undefined;
+    isArticleSaved: (article: NewsFeedItem) => boolean;
+    saveArticle: (article: NewsFeedItem) => Promise<unknown>;
+    openSaveDialog: (article: NewsFeedItem) => void;
+}) {
+    const relatedArticles = Array.isArray(item.relatedArticles) ? item.relatedArticles : [];
+
+    return (
+        <div className="space-y-2">
+            <NewsArticle
+                item={item}
+                iconUrl={getIconUrl(item.subscription_id || item.subscription_name)}
+                isSaved={isArticleSaved(item)}
+                onSave={() => saveArticle(item)}
+                onSaveOptions={() => openSaveDialog(item)}
+            />
+
+            {relatedArticles.length > 0 && (
+                <div className="ml-0 md:ml-[calc(25%+0.75rem)] rounded-xl bg-(--surface-2)/70 p-3">
+                    <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wide opacity-70">
+                        <Icon icon="fa6-solid:layer-group" />
+                        Similar topic
+                    </div>
+                    <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                        {relatedArticles.map((article, idx) => (
+                            <RelatedNewsArticle
+                                key={String(article.link || idx)}
+                                item={article}
+                                iconUrl={getIconUrl(article.subscription_id || article.subscription_name)}
+                            />
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function RelatedNewsArticle({ item, iconUrl }: { item: NewsFeedItem; iconUrl?: string }) {
+    return (
+        <a
+            href={item.link}
+            target="_blank"
+            className="grid grid-cols-[5rem_1fr] gap-2 rounded-lg frosted p-2 transition hover:bg-white/10"
+        >
+            {item.thumbnailUrl
+                ? (
+                    <img
+                        src={String(item.thumbnailUrl)}
+                        className="h-16 w-20 rounded-md object-cover"
+                    />
+                )
+                : <div className="h-16 w-20 rounded-md bg-white/5" />}
+            <div className="min-w-0">
+                <p className="line-clamp-2 text-sm font-medium leading-snug hover:text-primary">
+                    {item.title}
+                </p>
+                <div className="mt-1 flex items-center gap-1 text-xs opacity-70">
+                    {iconUrl && <img src={iconUrl} alt={item.subscription_name} className="h-3.5" />}
+                    <span className="truncate">{item.subscription_name}</span>
+                </div>
+            </div>
+        </a>
+    );
+}
+
+function NewsArticle({ item, iconUrl, isSaved, onSave, onSaveOptions }: { item: NewsFeedItem; iconUrl?: string; isSaved?: boolean; onSave?: () => void; onSaveOptions?: () => void }) {
     return (
         <div className="rounded-xl bg-(--surface-2) w-full">
             <div className="grid gap-3 grid-cols-1 md:grid-cols-[1fr_3fr]">

--- a/packages/types/sdk-types.ts
+++ b/packages/types/sdk-types.ts
@@ -101,6 +101,9 @@ export type NewsFeedItem = {
   pubDate: string | Date;
   subscription_id: string;
   subscription_name: string;
+  topicId?: string;
+  topicTitle?: string;
+  relatedArticles?: NewsFeedItem[];
   [key: string]: unknown;
 };
 

--- a/pocketbase/migrations/1781992400_created_newsTopics.js
+++ b/pocketbase/migrations/1781992400_created_newsTopics.js
@@ -1,0 +1,136 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = new Collection({
+    "createRule": null,
+    "deleteRule": null,
+    "fields": [
+      {
+        "autogeneratePattern": "[a-z0-9]{15}",
+        "hidden": false,
+        "id": "text3987564420",
+        "max": 15,
+        "min": 15,
+        "name": "id",
+        "pattern": "^[a-z0-9]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text2757296874",
+        "max": 0,
+        "min": 0,
+        "name": "userId",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text3861575285",
+        "max": 0,
+        "min": 0,
+        "name": "topicKey",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text2859100538",
+        "max": 0,
+        "min": 0,
+        "name": "title",
+        "pattern": "",
+        "presentable": true,
+        "primaryKey": false,
+        "required": true,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text2749855010",
+        "max": 0,
+        "min": 0,
+        "name": "newestArticleLink",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": false,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "json4189263284",
+        "maxSize": 0,
+        "name": "articleLinks",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "json"
+      },
+      {
+        "hidden": false,
+        "id": "json3038260440",
+        "maxSize": 0,
+        "name": "json",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "json"
+      },
+      {
+        "hidden": false,
+        "id": "autodate1312269007",
+        "name": "created",
+        "onCreate": true,
+        "onUpdate": false,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      },
+      {
+        "hidden": false,
+        "id": "autodate2456997432",
+        "name": "updated",
+        "onCreate": true,
+        "onUpdate": true,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      }
+    ],
+    "id": "pbc_1910000000",
+    "indexes": [
+      "CREATE UNIQUE INDEX `idx_newsTopics_user_topicKey` ON `newsTopics` (`userId`, `topicKey`)",
+      "CREATE INDEX `idx_newsTopics_user_updated` ON `newsTopics` (`userId`, `updated`)"
+    ],
+    "listRule": null,
+    "name": "newsTopics",
+    "system": false,
+    "type": "base",
+    "updateRule": null,
+    "viewRule": null
+  });
+
+  return app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_1910000000");
+
+  return app.delete(collection);
+})


### PR DESCRIPTION
## Summary
- add a newsTopics PocketBase collection for persisted article topic clusters
- group similar feed entries by title, description, categories, and tags in the news feed response
- render related articles under the newest matching article in a compact two-column layout

Fixes #191

## Tests
- bun run build in apps/backend
- bun run build in apps/web