### PR TITLE
WIP: Weather sunset/sunrise glanceable

### DIFF
--- a/packages/assets/integrations/weather.yaml
+++ b/packages/assets/integrations/weather.yaml
@@ -378,3 +378,20 @@ configuration:
             show_if: "${SHOW_LOCATION} == false"
           - text: " in ${WEATHER_LOCATION.name}"
             show_if: "${SHOW_LOCATION} != false"
+
+    - name: "Sunrise / Sunset"
+      key: "sunrise-sunset"
+      description: "Shows today's sunrise and sunset times."
+      properties:
+        lat: "${WEATHER_LOCATION.lat}"
+        lon: "${WEATHER_LOCATION.lon}"
+        displayName: "${WEATHER_LOCATION.name}"
+      icon:
+        file: "fa6-solid:sun"
+        size: 16
+        description: "Sunrise and sunset"
+      text:
+        operation: stringadd
+        inputs:
+          - text: "Sunrise ${computed.weather.fields.sunrise:time}"
+          - text: " · Sunset ${computed.weather.fields.sunset:time}"


### PR DESCRIPTION
## Summary
- Add a built-in Weather sunrise/sunset glanceable
- Reuse existing Open-Meteo daily sunrise and sunset computed fields
- Format values through the existing localized time cast

Closes #254

## Checks
- bun run typecheck
- bun -e "import { readFileSync } from 'fs'; import YAML from 'yaml'; YAML.parse(readFileSync('packages/assets/integrations/weather.yaml', 'utf8'));"
- bun run lint (blocked: local install is missing eslint-plugin-react-hooks)