### PR TITLE
Fix auth redirects for 404 and migrate flows

### DIFF
--- a/apps/web/src/app/(authenticated)/migrate/page.tsx
+++ b/apps/web/src/app/(authenticated)/migrate/page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import useAuth from "@/context/useAuth";
 import { Card } from "@/components/ui/card";
@@ -9,19 +9,22 @@ import { fixMissingTitlesAction } from '@/lib/apiClient';
 
 export default function MigratePage() {
   const [loading, setLoading] = useState(false);
-  const { token, user } = useAuth();
+  const { token, redirectToLogin, withAuthRedirect } = useAuth();
   const [result, setResult] = useState<string | null>(null);
 
-  const runMigration = async () => {
+  useEffect(() => {
     if (!token) {
-      setResult("Missing auth token");
-      return;
+      redirectToLogin();
     }
+  }, [redirectToLogin, token]);
 
+  if (!token) return null;
+
+  const runMigration = async () => {
     setLoading(true);
     setResult(null);
     try {
-      const res = await migrateLegacyPageConfigAction({ token });
+      const res = await withAuthRedirect(migrateLegacyPageConfigAction);
       setResult(JSON.stringify(res, null, 2));
     } catch (err) {
       setResult(String(err));
@@ -31,15 +34,10 @@ export default function MigratePage() {
   };
 
   const runFixMissingTitles = async () => {
-    if (!token) {
-      setResult("Missing auth token");
-      return;
-    }
-
     setLoading(true);
     setResult(null);
     try {
-      const res = await fixMissingTitlesAction({ token });
+      const res = await withAuthRedirect(fixMissingTitlesAction);
       setResult(JSON.stringify(res, null, 2));
     } catch (err) {
       setResult(String(err));

--- a/apps/web/src/components/errorPages/PageNotFound.tsx
+++ b/apps/web/src/components/errorPages/PageNotFound.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { createHomePageAction } from '@/lib/apiClient';
+import { createHomePageAction, validateAuthTokenAction } from '@/lib/apiClient';
 import useAuth from "@/context/useAuth";
 import {
 	Card,
@@ -19,10 +19,33 @@ type PageNotFoundProps = {
 };
 
 export default function PageNotFound({ pageName }: PageNotFoundProps) {
-	const { logout, withAuth } = useAuth();
+	const { token, logout, withAuth, withAuthRedirect, redirectToLogin } = useAuth();
 	const navigate = useNavigate();
 	const isHomePage = String(pageName ?? "").trim().toLowerCase() === "home";
 	const [creatingHomePage, setCreatingHomePage] = React.useState(false);
+
+	React.useEffect(() => {
+		if (!token) {
+			redirectToLogin();
+			return;
+		}
+
+		let cancelled = false;
+
+		const checkAuth = async () => {
+			try {
+				await withAuthRedirect(validateAuthTokenAction);
+			} catch {
+				if (cancelled) return;
+			}
+		};
+
+		checkAuth();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [redirectToLogin, token, withAuthRedirect]);
 
 	const handleLogout = () => {
 		try {

--- a/apps/web/src/context/useAuth.tsx
+++ b/apps/web/src/context/useAuth.tsx
@@ -3,6 +3,7 @@
 import { updateUserPropertyAction } from '@/lib/apiClient';
 import type { ActionAuth, AuthUserRecord, UserPropertyValue } from "@dashwise/types/sdk";
 import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 type AuthUser = AuthUserRecord;
 
@@ -16,6 +17,7 @@ function createUnauthorizedError() {
 }
 
 export function useAuth() {
+  const navigate = useNavigate();
   const [user, setUser] = useState<AuthUser>(() => {
     try {
       const raw = typeof window !== "undefined" ? localStorage.getItem("pb_user") : null;
@@ -133,6 +135,18 @@ export function useAuth() {
     [token]
   );
 
+  const redirectToLogin = useCallback(() => {
+    logout();
+    navigate("/auth/login", { replace: true });
+  }, [logout, navigate]);
+
+  const withAuthRedirect = useCallback(
+    async <T,>(fn: (auth: ActionAuth) => Promise<T>): Promise<T> => {
+      return withAuth(fn, redirectToLogin);
+    },
+    [redirectToLogin, withAuth]
+  );
+
   const updateUserProperty = useCallback(
     async (propertyName: string, propertyValue: UserPropertyValue) => {
       const updatedUser = await withAuth((auth) =>
@@ -145,7 +159,7 @@ export function useAuth() {
     [token, withAuth, setAuth]
   );
 
-  return { user, token, setAuth, setToken: setTokenOnly, logout, withAuth, updateUserProperty };
+  return { user, token, setAuth, setToken: setTokenOnly, logout, withAuth, withAuthRedirect, redirectToLogin, updateUserProperty };
 }
 
 

--- a/apps/web/src/lib/apiClient.ts
+++ b/apps/web/src/lib/apiClient.ts
@@ -32,6 +32,35 @@ client.setConfig({
   baseUrl: (getBaseUrl() ?? "").replace(/\/+$/, "") + apiBasePath,
 });
 
+function redirectToLoginAfterUnauthorized() {
+  if (typeof window === "undefined") return;
+
+  localStorage.removeItem("pb_user");
+  localStorage.removeItem("pb_token");
+  document.cookie = "pb_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax; Secure";
+  document.cookie = "pb_user=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax; Secure";
+
+  if (window.location.pathname !== "/auth/login") {
+    window.location.assign("/auth/login");
+  }
+}
+
+function handleUnauthorizedResponse(response?: Response) {
+  if (response?.status === 401) {
+    redirectToLoginAfterUnauthorized();
+  }
+}
+
+client.interceptors.response.use((response) => {
+  handleUnauthorizedResponse(response);
+  return response;
+});
+
+client.interceptors.error.use((error, response) => {
+  handleUnauthorizedResponse(response);
+  return error;
+});
+
 export function backendUrl(path: string) {
   return new URL(path.replace(/^\/+/, ""), getBaseUrl()).toString();
 }
@@ -85,9 +114,12 @@ function isWallpaperApiUrl(url: URL) {
   return url.pathname === "/api/v1/wallpapers" || url.pathname.endsWith("/api/v1/wallpapers");
 }
 
-export async function extractData<T>(result: { data?: T; error?: unknown }): Promise<T> {
+export async function extractData<T>(result: { data?: T; error?: unknown; response?: Response }): Promise<T> {
   if (result?.error) {
-    throw new Error(stringifyError(result.error));
+    const error = new Error(stringifyError(result.error)) as Error & { status?: number; body?: unknown };
+    error.status = result.response?.status;
+    error.body = result.error;
+    throw error;
   }
   return result?.data as T;
 }
@@ -99,6 +131,8 @@ export async function fetchWallpaperBlob(imageUrl: string, token?: string): Prom
     const response = await fetch(url.toString(), {
       headers: token ? { Authorization: `Bearer ${token}` } : undefined,
     });
+
+    handleUnauthorizedResponse(response);
 
     if (!response.ok) {
       throw new Error("Failed to fetch wallpaper");
@@ -368,9 +402,13 @@ async function fetchJsonAction<T>(auth: ActionAuth, path: string, init?: Request
       ...(init?.headers || {}),
     },
   });
+  handleUnauthorizedResponse(response);
   const data = await response.json().catch(() => null);
   if (!response.ok || data?._status >= 400) {
-    throw new Error(data?.error || data?.message || "Request failed");
+    const error = new Error(data?.error || data?.message || "Request failed") as Error & { status?: number; body?: unknown };
+    error.status = response.status;
+    error.body = data;
+    throw error;
   }
   return data as T;
 }


### PR DESCRIPTION
## Summary\n- add auth-context redirect helper\n- redirect unauthenticated 404 and migrate flows to login\n- redirect to login on Dashwise API 401 responses\n\n## Verification\n- bun run lint (blocked: missing eslint-plugin-react-hooks)\n- bunx tsc --noEmit -p tsconfig.json (blocked by existing repo-wide type errors)