### PR TITLE
Show monitor name correctly for links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ This repository is a Bun-based monorepo for `dashwise`, a self-hosted homelab da
 - Avoid introducing new package managers or build systems.
 - Prefer modifying existing shared packages in `packages/` when changes affect both apps.
 - Preserve PocketBase migration structure in `pocketbase/migrations` when updating schema or collection configuration.
-- Use design.md standars for designing uis.
+- Use design.md standards for designing uis.
 
 ## Useful commands
 

--- a/apps/backend/src/lib/data/monitoring.ts
+++ b/apps/backend/src/lib/data/monitoring.ts
@@ -39,6 +39,13 @@ export interface MonitorRecord extends Pick<
 > {
   method?: string;
   linkId?: string;
+  expand?: {
+    sourcelinkId?: {
+      title?: string;
+      url?: string;
+    };
+    [key: string]: unknown;
+  };
   [key: string]: unknown;
 }
 
@@ -181,14 +188,19 @@ function getLatestMonitorStatus(monitor: any): MonitorStatusSummary {
 
 export async function getMonitors(userId: string) {
   const pb = await getSuperuserPB();
-  return pb.collection("monitors").getFullList({ filter: `userId = "${userId}"` });
+  return pb.collection("monitors").getFullList({
+    filter: `userId = "${userId}"`,
+    expand: "sourcelinkId",
+  });
 }
 
 export async function getMonitorById(userId: string, monitorId: string) {
   const pb = await getSuperuserPB();
 
   try {
-    const monitor = await pb.collection("monitors").getOne(monitorId);
+    const monitor = await pb.collection("monitors").getOne(monitorId, {
+      expand: "sourcelinkId",
+    });
     return monitor?.userId === userId ? monitor : null;
   } catch {
     return null;

--- a/apps/web/src/app/(authenticated)/apps/monitoring/[monitorId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/apps/monitoring/[monitorId]/page.tsx
@@ -392,9 +392,9 @@ export default function MonitoringDetailPage() {
         );
     }
 
-    const monitorTitle = linkEntry?.title || monitor.endpoint ||
+    const monitorTitle = monitor.expand?.sourcelinkId?.title || linkEntry?.title || monitor.endpoint ||
         monitor.sourcelinkId || monitor.source || monitor.id;
-    const monitoredUrl = linkEntry?.url || monitor.endpoint || "Unknown";
+    const monitoredUrl = monitor.expand?.sourcelinkId?.url || linkEntry?.url || monitor.endpoint || "Unknown";
     const method = String(monitor.method || "GET").toUpperCase();
     const changeLabel = formatStatusLabel(currentStatus);
 

--- a/apps/web/src/app/(authenticated)/apps/monitoring/layout.tsx
+++ b/apps/web/src/app/(authenticated)/apps/monitoring/layout.tsx
@@ -88,7 +88,7 @@ export default function MonitoringRootLayout() {
                         key={monitor.id}
                         dst={`/apps/monitoring/${monitor.id}`}
                         icon="fa6-solid:server"
-                        title={entry?.title || monitor.endpoint || monitor.sourcelinkId || monitor.source || monitor.id}
+                        title={monitor.expand?.sourcelinkId?.title || entry?.title || monitor.endpoint || monitor.sourcelinkId || monitor.source || monitor.id}
                         group="Monitors"
                         badge={monitor.status ? monitor.status : undefined}
                     />

--- a/apps/web/src/app/(authenticated)/apps/monitoring/page.tsx
+++ b/apps/web/src/app/(authenticated)/apps/monitoring/page.tsx
@@ -93,7 +93,7 @@ function formatStatusLabel(status?: string) {
 }
 
 function getMonitorTitle(monitor: MonitorRecord) {
-    return monitor.endpoint || monitor.sourcelinkId || monitor.source || monitor.id;
+    return monitor.expand?.sourcelinkId?.title || monitor.endpoint || monitor.sourcelinkId || monitor.source || monitor.id;
 }
 
 function getCurrentStatus(monitor: MonitorRecord) {

--- a/packages/types/sdk-types.ts
+++ b/packages/types/sdk-types.ts
@@ -63,6 +63,13 @@ export type MonitorRecord = {
   updated: string;
   method?: string;
   linkId?: string;
+  expand?: {
+    sourcelinkId?: {
+      title?: string;
+      url?: string;
+    };
+    [key: string]: unknown;
+  };
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
## Summary
- expand monitor link relations in monitor list and detail responses
- use linked item titles for monitor names across monitoring views
- retain endpoint and ID fallbacks for unlinked monitors

Closes #283