### PR TITLE
Monitoring: add SSH hosts as shortcuts

### DIFF
--- a/apps/backend/src/jobs/search-indexer.ts
+++ b/apps/backend/src/jobs/search-indexer.ts
@@ -67,6 +67,29 @@ export async function runSearchItemsIndexing() {
       });
     }
 
+    const sshHosts = await pb.collection("monitoringHosts").getFullList(500, {
+      filter: `userId="${escapeFilter(userId)}" && type="ssh"`,
+      sort: "name",
+    }).catch(() => [] as Array<Record<string, any>>);
+
+    for (const host of sshHosts) {
+      const hostId = String(host?.id ?? "").trim();
+      const hostname = String(host?.hostname ?? "").trim();
+      if (!hostId || !hostname) continue;
+
+      const name = String(host?.name ?? "").trim() || hostname;
+      rows.push({
+        name,
+        icon: "fa6-solid:terminal",
+        secondary: `SSH - ${hostname}${host?.port ? `:${host.port}` : ""}`,
+        action: `url:/apps/monitoring/ssh?host=${encodeURIComponent(hostId)}`,
+        app: "",
+        tags: [name, hostname, "ssh"],
+        sourceId: `monitoring-ssh-host:${hostId}`,
+        sourceUpdated: String(host?.updated ?? ""),
+      });
+    }
+
     const enabledIntegrations = await getEnabledIntegrationsMap(pb, userId);
     const integrations = await pb.collection("integrations").getFullList<SearchIndexIntegrationRecord>(500, {
       filter: `user=\"${userId.replace(/"/g, '\\\"')}\"`,


### PR DESCRIPTION
Closes #281

## Summary
- index user SSH hosts as shortcut/search items
- open hosts through /apps/monitoring/ssh?host=<id>
- preserve automatic shortcut cleanup and updates through the existing search indexer

## Verification
- bun run --cwd apps/backend build
- bun run --cwd apps/web build
- bun run lint -- apps/backend/src/jobs/search-indexer.ts