### PR TITLE
fix(news): correct feed pagination

### DIFF
--- a/apps/web/src/components/news/NewsDashboard.tsx
+++ b/apps/web/src/components/news/NewsDashboard.tsx
@@ -550,15 +550,16 @@ export default function NewsDashboardComponent() {
         : [];
 
     const totalPages = Math.ceil(feedTotal / itemsPerPage);
-    const paginatedArticles = allArticles.slice(
-        (currentPage - 1) * itemsPerPage,
-        currentPage * itemsPerPage,
-    );
+    const paginatedArticles = activeSavedList
+        ? allArticles.slice(
+            (currentPage - 1) * itemsPerPage,
+            currentPage * itemsPerPage,
+        )
+        : allArticles;
 
     const handlePageChange = (page: number) => {
         if (page === currentPage) return;
         setCurrentPage(page);
-        void loadFeed();
     };
 
     return (


### PR DESCRIPTION
## Summary
- fix regular news feeds rendering empty pages after the first page
- keep saved article lists on local pagination
- rely on the page-specific query key instead of refetching the stale page

## Root cause
The API already applies `limit` and `offset` for regular feeds. The dashboard sliced that response again using the current page offset, so page 2 sliced items 15-29 a second time and rendered nothing.

## Verification
- `bun run lint` (apps/web)
- `bun run build` (apps/web)
- `bun run build` (apps/backend)
- `bun run typecheck` (workspace)